### PR TITLE
Only call GetCollection on a meta when getting the form template

### DIFF
--- a/admin/func_map.go
+++ b/admin/func_map.go
@@ -227,7 +227,7 @@ func (context *Context) RenderMeta(meta *Meta, value interface{}, prefix []strin
 			"Meta":          meta,
 		}
 
-		if meta.GetCollection != nil {
+		if meta.GetCollection != nil && metaType == "form" {
 			data["CollectionValue"] = meta.GetCollection(value, context.Context)
 		}
 


### PR DESCRIPTION
This stops listings retrieving every row of associated tables and should give a speed boost although it might be best to let the meta object decide if it's needed or not.