### PR TITLE
Probe template dirs in reverse order

### DIFF
--- a/admin/context.go
+++ b/admin/context.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 
 	"github.com/qor/qor"
 	"github.com/qor/qor/utils"
@@ -97,6 +98,8 @@ func (context *Context) getViewPaths() (paths []string) {
 			}
 		}
 	}
+
+	sort.Sort(sort.StringSlice(paths))
 	return paths
 }
 

--- a/admin/template.go
+++ b/admin/template.go
@@ -21,8 +21,8 @@ func init() {
 		Root = root
 	}
 
-	registerViewPath(path.Join(Root, "app/views/qor"))
 	RegisterViewPath("github.com/qor/qor/admin/views")
+	registerViewPath(path.Join(Root, "app/views/qor"))
 }
 
 // RegisterViewPath register views directory
@@ -32,6 +32,8 @@ func RegisterViewPath(p string) {
 	for _, gopath := range strings.Split(os.Getenv("GOPATH"), ":") {
 		registerViewPath(path.Join(gopath, "src", p))
 	}
+
+	registerViewPath(path.Join(Root, p))
 }
 
 func isExistingDir(pth string) bool {


### PR DESCRIPTION
What happens now:

* qor check firstly qor built-in templates
* then vendor templates
* then specified by RegisterViewPath pathes
* then PWD

I think that logical order is reversed, i.e. firstly try to find a template in a dir that was registered last, then the previous, then vendor and built-ins are the last. 