### PR TITLE
fix field name collision

### DIFF
--- a/resource/crud.go
+++ b/resource/crud.go
@@ -35,7 +35,7 @@ func (res *Resource) findOneHandler(result interface{}, metaValues *MetaValues, 
 					}
 				}
 			}
-			return context.GetDB().First(result, fmt.Sprintf("%v = ?", scope.Quote(primaryField.DBName)), primaryKey).Error
+			return context.GetDB().First(result, fmt.Sprintf("%v.%v = ?", scope.QuotedTableName(), scope.Quote(primaryField.DBName)), primaryKey).Error
 		}
 		return errors.New("failed to find")
 	}


### PR DESCRIPTION
if findOneHandler() gets called with a JOIN construction,
multiple fields with the same name will prompt a disambiguation
error from the underlying database. (observed in postgres)