### PR TITLE
Fix nil panic for converting nested json to metavalue

### DIFF
--- a/resource/schema.go
+++ b/resource/schema.go
@@ -21,21 +21,25 @@ func convertMapToMetaValues(values map[string]interface{}, metaors []Metaor) (*M
 	for key, value := range values {
 		var metaValue *MetaValue
 		metaor := metaorMap[key]
+		var childMeta []Metaor
+		if metaor != nil {
+			childMeta = metaor.GetMetas()
+		}
 
 		switch result := value.(type) {
 		case map[string]interface{}:
-			if children, err := convertMapToMetaValues(result, metaor.GetMetas()); err == nil {
+			if children, err := convertMapToMetaValues(result, childMeta); err == nil {
 				metaValue = &MetaValue{Name: key, Meta: metaor, MetaValues: children}
 			}
 		case []interface{}:
 			for idx, r := range result {
 				if mr, ok := r.(map[string]interface{}); ok {
-					if children, err := convertMapToMetaValues(mr, metaor.GetMetas()); err == nil {
+					if children, err := convertMapToMetaValues(mr, childMeta); err == nil {
 						metaValue := &MetaValue{Name: key, Meta: metaor, MetaValues: children, Index: idx}
 						metaValues.Values = append(metaValues.Values, metaValue)
 					}
 				} else {
-					metaValue := &MetaValue{Name: key, Value: result, Meta: metaor}
+					metaValue := &MetaValue{Name: key, Value: result, Meta: metaor, Index: idx}
 					metaValues.Values = append(metaValues.Values, metaValue)
 					break
 				}


### PR DESCRIPTION
If you use a struct of multi-level json, you can cause a nil panic. `metaor.GetMetas()` may return nil the first time, but when one recurses, it will try calling `GetMetas()` on a `nil` object.  Oops.

You can trigger this by posting something like this to qor admin:

```
{
	"Author": "Super",
	"CreatedAt": "2016-09-29 16:51",
	"ID": 18,
	"Object": {
		"sub": {
			"name": "foo"
		}
	},
	"Title": "Duper"
}
```

For more details see my issue on the admin interface: https://github.com/qor/admin/issues/39

